### PR TITLE
Update parser from babylon to babel

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = {
         bracketSpacing: true,
         jsxBracketSameLine: false,
         semi: false,
-        parser: 'babylon',
+        parser: 'babel',
         printWidth: 100,
       },
     ],


### PR DESCRIPTION
- This PR fixes an issue from eslint warning that babylon has been deprecated