### PR TITLE
Add official eslint plugin for hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,8 +49,6 @@ module.exports = {
         printWidth: 100,
       },
     ],
-    'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/exhausistive-deps': 'warn',
   },
-  plugins: ['prettier', 'react-hooks'],
+  plugins: ['prettier'],
 };

--- a/index.js
+++ b/index.js
@@ -49,6 +49,8 @@ module.exports = {
         printWidth: 100,
       },
     ],
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhausistive-deps': 'warn',
   },
-  plugins: ['prettier'],
+  plugins: ['prettier', 'react-hooks'],
 };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-prettier": "^2.3.1",
     "eslint-plugin-react": "^7.3.0",
+    "eslint-plugin-react-hooks": "^1.6.0",
     "prettier": "^1.7.4"
   },
   "peerDependencies": {

--- a/react.js
+++ b/react.js
@@ -5,10 +5,12 @@ module.exports = {
   rules: {
     'jsx-a11y/href-no-hash': 0,
     'react/jsx-filename-extension': 'off',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhausistive-deps': 'warn',
   },
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module',
   },
-  plugins: ['react'],
+  plugins: ['react', 'react-hooks'],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,6 +404,11 @@ eslint-plugin-prettier@^2.3.1:
     fast-diff "^1.1.1"
     jest-docblock "^21.0.0"
 
+eslint-plugin-react-hooks@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz#348efcda8fb426399ac7b8609607c7b4025a6f5f"
+  integrity sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==
+
 eslint-plugin-react@^7.3.0:
   version "7.10.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.10.0.tgz#af5c1fef31c4704db02098f9be18202993828b50"


### PR DESCRIPTION
The React team has set the Rules of Hook: 

1. Only call hooks at the top level;
2. Only call hooks on react functions.

They added constrictions to enforce this in a eslint plugin, so I added it as recommended by the package to Cheesecake Labs' default linter.

The page discussing this can be found [here](https://reactjs.org/docs/hooks-rules.html).
The package is [here](https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks).