### PR TITLE
feat: Update nodejs to LTS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-cheesecakelabs",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "This package provides CheesecakeLab's .eslintrc extensible shared config.",
   "main": "./index.js",
   "repository": {
@@ -21,7 +21,7 @@
     "cheesecakelabs"
   ],
   "engines": {
-    "node": ">=11.10.1"
+    "node": ">=12.13.1"
   },
   "engineStrict": true,
   "dependencies": {


### PR DESCRIPTION
As shown in the [NodeJS website](https://nodejs.org/en/) at this date, the actual LTS version is 12.3.1, instead of 11.

![image](https://user-images.githubusercontent.com/7551787/70548778-e6668200-1b51-11ea-85d7-9422e8623bae.png)
